### PR TITLE
Only generate IAM policy on provision (not on deprovision).

### DIFF
--- a/roles/sqs-apb-openshift/tasks/main.yml
+++ b/roles/sqs-apb-openshift/tasks/main.yml
@@ -31,6 +31,7 @@
   template:
     src: "{{ role_path }}/files/SQSAccessPolicy.json.j2"
     dest: "/tmp/{{ stack_suffix }}.json"
+  when: state == 'present'
 
 - name: Attach SQS access IAM policy
   iam_policy:


### PR DESCRIPTION
IAM policy generate task was running on deprovision and failing due to `sqs_queue_arn` not being available. 
